### PR TITLE
feat: replace transfer with mint for localnet chain

### DIFF
--- a/pkg/wallet/token.go
+++ b/pkg/wallet/token.go
@@ -32,6 +32,13 @@ var chainToSwarmTokenMap = map[int64]Token{
 		Symbol:   "xBZZ",
 		Decimals: SwarmTokenDecimals,
 	},
+
+	// Localnet
+	12345: {
+		Contract: common.HexToAddress("0x6aab14fe9cccd64a502d23842d916eb5321c26e7"),
+		Symbol:   "tBZZ",
+		Decimals: SwarmTokenDecimals,
+	},
 }
 
 var chainToNativeCoinMap = map[int64]Token{
@@ -44,6 +51,12 @@ var chainToNativeCoinMap = map[int64]Token{
 	// Mainnet
 	100: {
 		Symbol:   "xDAI",
+		Decimals: 18,
+	},
+
+	// Localnet
+	12345: {
+		Symbol:   "tETH",
 		Decimals: 18,
 	},
 }

--- a/pkg/wallet/token.go
+++ b/pkg/wallet/token.go
@@ -10,7 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const SwarmTokenDecimals = 16
+const (
+	SwarmTokenDecimals = 16
+	LocalnetChainID    = 12345
+)
 
 type Token struct {
 	Contract common.Address
@@ -34,7 +37,7 @@ var chainToSwarmTokenMap = map[int64]Token{
 	},
 
 	// Localnet
-	12345: {
+	LocalnetChainID: {
 		Contract: common.HexToAddress("0x6aab14fe9cccd64a502d23842d916eb5321c26e7"),
 		Symbol:   "tBZZ",
 		Decimals: SwarmTokenDecimals,
@@ -55,7 +58,7 @@ var chainToNativeCoinMap = map[int64]Token{
 	},
 
 	// Localnet
-	12345: {
+	LocalnetChainID: {
 		Symbol:   "tETH",
 		Decimals: 18,
 	},

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -204,8 +204,8 @@ func (w *erc20Wallet) Transfer(
 
 	// Custom handling for LocalnetChainID.
 	if chainID.Int64() == LocalnetChainID {
-		localnetMintFunction, err := hex.DecodeString("40c10f19") // mint(address,uint256)
-		if err != nil {
+		localnetMintFunction, decodeErr := hex.DecodeString("40c10f19") // mint(address,uint256)
+		if decodeErr != nil {
 			return fmt.Errorf("failed decode string %w", err)
 		}
 		// Replace the first 4 bytes of the call data (transfer) with the localnet mint function.

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -6,6 +6,7 @@ package wallet
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strings"
@@ -191,9 +192,24 @@ func (w *erc20Wallet) Transfer(
 	amount *big.Int,
 	token Token,
 ) error {
+	chainID, err := w.client.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get network id, %w", err)
+	}
+
 	callData, err := erc20ABI.Pack("transfer", toAddr, amount)
 	if err != nil {
 		return fmt.Errorf("failed to pack abi, %w", err)
+	}
+
+	// Custom handling for LocalnetChainID.
+	if chainID.Int64() == LocalnetChainID {
+		localnetMintFunction, err := hex.DecodeString("40c10f19") // mint(address,uint256)
+		if err != nil {
+			return fmt.Errorf("failed decode string %w", err)
+		}
+		// Replace the first 4 bytes of the call data (transfer) with the localnet mint function.
+		copy(callData[:4], localnetMintFunction)
 	}
 
 	err = w.trxSender.Send(ctx, token.Contract, nil, callData)


### PR DESCRIPTION
This pull request enhances the Transfer function in the erc20Wallet by introducing a conditional check for the LocalnetChainID (12345). When the LocalnetChainID is detected, the code replaces the original ERC20 transfer function with a custom mint function. This change is aimed at improving compatibility and functionality specifically for the Localnet environment.